### PR TITLE
Add upload method

### DIFF
--- a/js/index.d.ts
+++ b/js/index.d.ts
@@ -5,6 +5,7 @@ declare class OutroAPI {
     static setBaseURL(baseURL: string): void;
     static post(endpoint: string, payload: any): Promise<any>;
     static form(endpoint: string, payload: FormData): Promise<any>;
+    static upload(endpoint: string, payload: FormData, onProgress: (percent: number) => void): Promise<any>;
     static get(endpoint: string): Promise<any>;
 }
 export default OutroAPI;

--- a/js/index.js
+++ b/js/index.js
@@ -69,6 +69,31 @@ class OutroAPI {
             }
         });
     }
+    static upload(endpoint, payload, onProgress) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve, reject) => {
+                if (!endpoint) {
+                    throw new Error('No endpoint specified');
+                }
+                try {
+                    const req = new XMLHttpRequest();
+                    req.upload.addEventListener('progress', (e) => {
+                        const percent = e.loaded / e.total * 100;
+                        onProgress(percent);
+                    });
+                    req.addEventListener('load', () => {
+                        resolve(JSON.parse(req.response));
+                    });
+                    req.open('POST', this.baseURL + endpoint);
+                    req.setRequestHeader('Authorization', `Bearer ${this.authToken}`);
+                    req.send(payload);
+                }
+                catch (err) {
+                    reject(err);
+                }
+            });
+        });
+    }
     static get(endpoint) {
         return __awaiter(this, void 0, void 0, function* () {
             if (!endpoint) {

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -39,7 +39,7 @@ class OutroAPI {
       return await response.json();
     }
     catch (e) {
-      throw new Error(`post to ${endpoint} failed: ${e.message}`)
+      throw new Error(`post to ${endpoint} failed: ${e.message}`);
     }
   }
 
@@ -62,8 +62,37 @@ class OutroAPI {
       return await response.json();
     }
     catch (e) {
-      throw new Error(`form to ${endpoint} failed: ${e.message}`)
+      throw new Error(`form to ${endpoint} failed: ${e.message}`);
     }
+  }
+
+  public static async upload(endpoint: string, payload: FormData, onProgress: (percent: number) => void): Promise<any> {
+    return new Promise((resolve, reject) => {
+      if (!endpoint) {
+        throw new Error('No endpoint specified');
+      }
+
+      try {
+        const req = new XMLHttpRequest();
+
+        req.upload.addEventListener('progress', (e: ProgressEvent) => {
+          const percent = e.loaded / e.total * 100;
+          onProgress(percent);
+        });
+
+        req.addEventListener('load', () => {
+          resolve(JSON.parse(req.response));
+        });
+
+        req.open('POST', this.baseURL + endpoint);
+        req.setRequestHeader('Authorization', `Bearer ${this.authToken}`);
+        req.send(payload);
+      }
+
+      catch (err) {
+        reject(err);
+      }
+    });
   }
 
   public static async get(endpoint: string): Promise<any> {
@@ -83,7 +112,7 @@ class OutroAPI {
       return await response.json();
     }
     catch (e) {
-      throw new Error(`get from ${endpoint} failed: ${e.message}`)
+      throw new Error(`get from ${endpoint} failed: ${e.message}`);
     }
   }
 }


### PR DESCRIPTION
Since using `fetch` we cannot get uploadProgress, we had to create a new method for `upload` which uses ye old `XMLHttpRequest`. This allows us to set up eventListeners to check for progress when uploading files.

If this is good, I'll make sure to port it over in the webapp side of things too